### PR TITLE
Refine criterion and matcher logging info

### DIFF
--- a/detrex/modeling/criterion/criterion.py
+++ b/detrex/modeling/criterion/criterion.py
@@ -245,3 +245,20 @@ class SetCriterion(nn.Module):
             return losses, indices_list
 
         return losses
+
+
+    def __repr__(self):
+        head = "Criterion " + self.__class__.__name__
+        body = [
+            "matcher: {}".format(self.matcher.__repr__(_repr_indent=8)),
+            "losses: {}".format(self.losses),
+            "loss_class_type: {}".format(self.loss_class_type),
+            "weight_dict: {}".format(self.weight_dict),
+            "num_classes: {}".format(self.num_classes),
+            "eos_coef: {}".format(self.eos_coef),
+            "focal loss alpha: {}".format(self.alpha),
+            "focal loss gamma: {}".format(self.gamma),
+        ]
+        _repr_indent = 4
+        lines = [head] + [" " * _repr_indent + line for line in body]
+        return "\n".join(lines)

--- a/detrex/modeling/matcher/matcher.py
+++ b/detrex/modeling/matcher/matcher.py
@@ -149,3 +149,16 @@ class HungarianMatcher(nn.Module):
             (torch.as_tensor(i, dtype=torch.int64), torch.as_tensor(j, dtype=torch.int64))
             for i, j in indices
         ]
+
+    def __repr__(self, _repr_indent=4):
+        head = "Matcher " + self.__class__.__name__
+        body = [
+            "cost_class: {}".format(self.cost_class),
+            "cost_bbox: {}".format(self.cost_bbox),
+            "cost_giou: {}".format(self.cost_giou),
+            "cost_class_type: {}".format(self.cost_class_type),
+            "focal cost alpha: {}".format(self.alpha),
+            "focal cost gamma: {}".format(self.gamma),
+        ]
+        lines = [head] + [" " * _repr_indent + line for line in body]
+        return "\n".join(lines)


### PR DESCRIPTION
## TODO
- [x] Refine logging for criterion and matcher to make it more readable in log follow [Mask2Former](https://github.com/facebookresearch/Mask2Former)

## example
- original logging in DINO
```bash
(criterion): DINOCriterion(
  (matcher): HungarianMatcher()
)
```

- modified version
```bash
(criterion): Criterion DINOCriterion
    matcher: Matcher HungarianMatcher
        cost_class: 2.0
        cost_bbox: 5.0
        cost_giou: 2.0
        cost_class_type: focal_loss_cost
        focal cost alpha: 0.25
        focal cost gamma: 2.0
    losses: ['class', 'boxes']
    loss_class_type: focal_loss
    weight_dict: {'loss_class': 1, 'loss_bbox': 5.0, 'loss_giou': 2.0, 'loss_class_dn': 1, 'loss_bbox_dn': 5.0, 'loss_giou_dn': 2.0, 'loss_class_enc': 1, 'loss_bbox_enc': 5.0, 'loss_giou_enc': 2.0, 'loss_class_dn_enc': 1, 'loss_bbox_dn_enc': 5.0, 'loss_giou_dn_enc': 2.0, 'loss_class_0': 1, 'loss_bbox_0': 5.0, 'loss_giou_0': 2.0, 'loss_class_dn_0': 1, 'loss_bbox_dn_0': 5.0, 'loss_giou_dn_0': 2.0, 'loss_class_1': 1, 'loss_bbox_1': 5.0, 'loss_giou_1': 2.0, 'loss_class_dn_1': 1, 'loss_bbox_dn_1': 5.0, 'loss_giou_dn_1': 2.0, 'loss_class_2': 1, 'loss_bbox_2': 5.0, 'loss_giou_2': 2.0, 'loss_class_dn_2': 1, 'loss_bbox_dn_2': 5.0, 'loss_giou_dn_2': 2.0, 'loss_class_3': 1, 'loss_bbox_3': 5.0, 'loss_giou_3': 2.0, 'loss_class_dn_3': 1, 'loss_bbox_dn_3': 5.0, 'loss_giou_dn_3': 2.0, 'loss_class_4': 1, 'loss_bbox_4': 5.0, 'loss_giou_4': 2.0, 'loss_class_dn_4': 1, 'loss_bbox_dn_4': 5.0, 'loss_giou_dn_4': 2.0}
    num_classes: 80
    eos_coef: None
    focal loss alpha: 0.25
    focal loss gamma: 2.0
```