### PR TITLE
fix demo confidence filter not to remove mask predictions

### DIFF
--- a/demo/predictors.py
+++ b/demo/predictors.py
@@ -1,5 +1,6 @@
 import atexit
 import bisect
+from copy import copy
 import multiprocessing as mp
 from collections import deque
 import cv2
@@ -13,19 +14,12 @@ from detectron2.utils.visualizer import ColorMode, Visualizer
 
 
 def filter_predictions_with_confidence(predictions, confidence_threshold=0.5):
-    preds = predictions["instances"]
-    keep_idxs = preds.scores > confidence_threshold
-    pred_scores = preds.scores[keep_idxs]
-    pred_classes = preds.pred_classes[keep_idxs]
-    pred_boxes = preds.pred_boxes[keep_idxs]
-    return {
-        "instances": Instances(
-            image_size=preds.image_size,
-            pred_boxes=pred_boxes,
-            scores=pred_scores,
-            pred_classes=pred_classes,
-        )
-    }
+    if "instances" in predictions:
+        preds = predictions["instances"]
+        keep_idxs = preds.scores > confidence_threshold
+        predictions = copy(predictions) # don't modify the original
+        predictions["instances"] = preds[keep_idxs]
+    return predictions
 
 
 class VisualizationDemo(object):


### PR DESCRIPTION
The function `filter_predictions_with_confidence` under `demo/predictors.py` destroys all info other than instances'           image_size, pred_boxes, scores, and pred_classes. Because of that, the demo doesn't visualize the mask.

Fix it by allowing `filter_predictions_with_confidence` to modify the instances only and apply it to all fields under instances.
