### PR TITLE
[Feature] Support wandb logging and vis training samples

### DIFF
--- a/configs/common/train.py
+++ b/configs/common/train.py
@@ -33,8 +33,8 @@ train = dict(
     eval_period=5000,
     # Output log to console every `log_period` number of iterations.
     log_period=20,
-
     # wandb logging params
+    # note that you should add wandb writer in `train_net.py``
     wandb=dict(
         enabled=False,
         params=dict(
@@ -43,7 +43,7 @@ train = dict(
             name="detrex_experiment",
         )
     ),
-
+    # the training device, choose from {"cuda", "cpu"}
     device="cuda",
     # ...
 )

--- a/configs/common/train.py
+++ b/configs/common/train.py
@@ -33,6 +33,17 @@ train = dict(
     eval_period=5000,
     # Output log to console every `log_period` number of iterations.
     log_period=20,
+
+    # wandb logging params
+    wandb=dict(
+        enabled=False,
+        params=dict(
+            dir="./wandb_output",
+            project="detrex",
+            name="detrex_experiment",
+        )
+    )
+
     device="cuda"
     # ...
 )

--- a/configs/common/train.py
+++ b/configs/common/train.py
@@ -42,8 +42,8 @@ train = dict(
             project="detrex",
             name="detrex_experiment",
         )
-    )
+    ),
 
-    device="cuda"
+    device="cuda",
     # ...
 )

--- a/detrex/utils/__init__.py
+++ b/detrex/utils/__init__.py
@@ -23,3 +23,4 @@ from .dist import (
     get_world_size,
     get_rank,
 )
+from .events import WandbWriter

--- a/detrex/utils/events.py
+++ b/detrex/utils/events.py
@@ -1,0 +1,52 @@
+# coding=utf-8
+# Copyright 2022 The IDEA Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from detectron2.utils.events import EventWriter, get_event_storage
+
+
+class WandbWriter(EventWriter):
+    """
+    Write all scalars to a wandb file.
+    """
+
+    def __init__(self, cfg, window_size: int = 20, **kwargs):
+        """
+        Args:
+            log_dir (str): the directory to save the output events
+            window_size (int): the scalars will be median-smoothed by this window size
+
+            kwargs: other arguments passed to `torch.utils.tensorboard.SummaryWriter(...)`
+        """
+        self._window_size = window_size
+        import wandb
+
+        self._writer = wandb.init(
+            config=cfg,
+            **cfg.wandb.params,
+        )
+    
+    def write(self):
+        storage = get_event_storage()
+        new_last_write = self._last_write
+        for k, (v, iter) in storage.latest_with_smoothing_hint(self._window_size).items():
+            if iter > self._last_write:
+                self._writer.log({k: v}, step=iter)
+                new_last_write = max(new_last_write, iter)
+        self._last_write = new_last_write
+    
+    def close(self):
+        if hasattr(self, "_writer"):
+            self._writer.finish()

--- a/detrex/utils/events.py
+++ b/detrex/utils/events.py
@@ -35,8 +35,9 @@ class WandbWriter(EventWriter):
 
         self._writer = wandb.init(
             config=cfg,
-            **cfg.wandb.params,
+            **cfg.train.wandb.params,
         )
+        self._last_write = -1
     
     def write(self):
         storage = get_event_storage()

--- a/detrex/utils/events.py
+++ b/detrex/utils/events.py
@@ -54,7 +54,7 @@ class WandbWriter(EventWriter):
             for img_name, img, step_num in storage._vis_data:
                 log_img = Image.fromarray(img.transpose(1, 2, 0))  # convert to (h, w, 3) PIL.Image
                 log_img = wandb.Image(log_img, caption=img_name)
-                self._writer.log({img_name: log_img}, step=step_num)
+                self._writer.log({img_name: [log_img]})
             # Storage stores all image data and rely on this writer to clear them.
             # As a result it assumes only one writer will use its image data.
             # An alternative design is to let storage store limited recent

--- a/docs/source/tutorials/FAQs.md
+++ b/docs/source/tutorials/FAQs.md
@@ -1,6 +1,8 @@
 # Frequently Asked Questions
 Here we provided some common troubles faced by the users and their corresponding solutions here. If the contents here do not cover your issue, please create an issue about it.
 
+We've already opened an issue about FAQs, please refer to [Frequently Asked Questions](https://github.com/IDEA-Research/detrex/issues/109) for more details.
+
 ## Training
 - "assert (boxes1[:, 2:] >= boxes1[:, :2]).all()" in `generalized_box_iou`
     This means the model produces **illegal box predictions**. You may solute this issue as follows:

--- a/docs/source/tutorials/Model_Zoo.md
+++ b/docs/source/tutorials/Model_Zoo.md
@@ -333,7 +333,7 @@ Here we provides our pretrained baselines with **detrex**. And more pretrained w
  <tr><td align="left"> <a href="https://github.com/IDEA-Research/detrex/blob/main/projects/dino/configs/dino_vitdet_large_4scale_12ep.py"> DINO-ViTDet-Large-4scale </a> </td>
 <td align="center">ViT</td>
 <td align="center">IN1k, MAE</td>
-<td align="center">50</td>
+<td align="center">12</td>
 <td align="center">100</td>
 <td align="center">52.9</td>
 <td align="center"> <a href="https://github.com/IDEA-Research/detrex-storage/releases/download/v0.2.1/dino_vitdet_large_4scale_12ep.pth"> model </a></td>

--- a/projects/dino/configs/models/dino_r50.py
+++ b/projects/dino/configs/models/dino_r50.py
@@ -102,6 +102,8 @@ model = L(DINO)(
     box_noise_scale=1.0,
     pixel_mean=[123.675, 116.280, 103.530],
     pixel_std=[58.395, 57.120, 57.375],
+    vis_period=0,
+    input_format="RGB",
     device="cuda",
 )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pytest
 scipy==1.7.3
 psutil
 opencv-python
+wandb

--- a/tools/train_net.py
+++ b/tools/train_net.py
@@ -32,6 +32,9 @@ from detectron2.engine import (
 from detectron2.engine.defaults import create_ddp_model
 from detectron2.evaluation import inference_on_dataset, print_csv_format
 from detectron2.utils import comm
+from detectron2.utils.file_io import PathManager
+
+from detrex.utils import WandbWriter
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir)))
 
@@ -182,6 +185,13 @@ def do_train(args, cfg):
         trainer=trainer,
     )
 
+    if comm.is_main_process():
+        writers = default_writers(cfg.train.output_dir, cfg.train.max_iter)
+        if cfg.train.wandb.enabled:
+            PathManager.mkdirs(cfg.train.wandb.params.dir)
+            wandb_writer = WandbWriter(cfg)
+            writers.append(wandb_writer)
+
     trainer.register_hooks(
         [
             hooks.IterationTimer(),
@@ -191,7 +201,7 @@ def do_train(args, cfg):
             else None,
             hooks.EvalHook(cfg.train.eval_period, lambda: do_test(cfg, model)),
             hooks.PeriodicWriter(
-                default_writers(cfg.train.output_dir, cfg.train.max_iter),
+                writers,
                 period=cfg.train.log_period,
             )
             if comm.is_main_process()


### PR DESCRIPTION
## TODO
- [x] visualization training samples through tensorboard in `DINO` by setting `model.vis_period=20` which will automatically log training samples each 20 iterations.
- [x] visualization training samples in wandb
- [x] add wandb logging training info

## Example
**Visualize training samples in tensorboard**
![image](https://user-images.githubusercontent.com/48727989/206381231-44ac8006-2021-4f9e-b5bf-b6f58267e20d.png)

- Note that we only visualize top-20 pred boxes in training