### PR TITLE
[Features] Support fast-dev-run for fast debugging

### DIFF
--- a/docs/source/tutorials/Getting_Started.md
+++ b/docs/source/tutorials/Getting_Started.md
@@ -96,3 +96,14 @@ python tools/train_net.py \
     --num-gpus 8 \
     --resume
 ```
+
+### Fast Debugging
+We have set an additional configuration for fast debugging named `cfg.train.fast_dev_run=bool`, which is `False` by default. if user enables this configuration, we perform it in a straightforward manner by setting `train.max_iter=20`, `train.eval_period=10`, `train.log_period=1`.
+
+To start fast debugging:
+```bash
+python tools/train_net.py \
+    --config-file projects/dab_detr/configs/dab_detr_r50_50ep.py \
+    --num-gpus 8 \
+    train.fast_dev_run.enabled=True
+```

--- a/docs/source/tutorials/Getting_Started.md
+++ b/docs/source/tutorials/Getting_Started.md
@@ -98,7 +98,7 @@ python tools/train_net.py \
 ```
 
 ### Fast Debugging
-We have set an additional configuration for fast debugging named `cfg.train.fast_dev_run=bool`, which is `False` by default. if user enables this configuration, we perform it in a straightforward manner by setting `train.max_iter=20`, `train.eval_period=10`, `train.log_period=1`.
+We have set an additional configuration for fast debugging named `train.fast_dev_run=bool`, which is `False` by default. if user enables this configuration, we perform it in a straightforward manner by setting `train.max_iter=20`, `train.eval_period=10`, `train.log_period=1`.
 
 To start fast debugging:
 ```bash

--- a/tools/train_net.py
+++ b/tools/train_net.py
@@ -235,6 +235,13 @@ def main(args):
     cfg = LazyConfig.apply_overrides(cfg, args.opts)
     default_setup(cfg, args)
 
+    if cfg.train.fast_dev_run.enabled:
+        logger.info("Enable fast debugging by running several iterations to check for any bugs. \
+                    Turn off this config to run normal experiments")
+        cfg.train.max_iter = 20
+        cfg.train.eval_period = 10
+        cfg.train.log_period = 1
+
     if args.eval_only:
         model = instantiate(cfg.model)
         model.to(cfg.train.device)

--- a/tools/train_net.py
+++ b/tools/train_net.py
@@ -43,8 +43,6 @@ from detrex.utils import WandbWriter
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir)))
 
-logger = logging.getLogger("detrex")
-
 
 class Trainer(SimpleTrainer):
     """
@@ -234,10 +232,9 @@ def main(args):
     cfg = LazyConfig.load(args.config_file)
     cfg = LazyConfig.apply_overrides(cfg, args.opts)
     default_setup(cfg, args)
-
+    
+    # Enable fast debugging by running several iterations to check for any bugs.
     if cfg.train.fast_dev_run.enabled:
-        logger.info("Enable fast debugging by running several iterations to check for any bugs. \
-                    Turn off this config to run normal experiments")
         cfg.train.max_iter = 20
         cfg.train.eval_period = 10
         cfg.train.log_period = 1


### PR DESCRIPTION
## TODO
- [x] support `train.fast_dev_run` configuration

## Usage
We have set an additional configuration for fast debugging named `cfg.train.fast_dev_run=bool`, which is `False` by default. if user enables this configuration, we perform it in a straightforward manner by setting `train.max_iter=20`, `train.eval_period=10`, `train.log_period=1`.

To start fast debugging:
```bash
python tools/train_net.py \
    --config-file projects/dab_detr/configs/dab_detr_r50_50ep.py \
    --num-gpus 8 \
    train.fast_dev_run.enabled=True
```