### PR TITLE
[Features] Support FP16 training

### DIFF
--- a/detrex/layers/multi_scale_deform_attn.py
+++ b/detrex/layers/multi_scale_deform_attn.py
@@ -324,9 +324,11 @@ class MultiScaleDeformableAttention(nn.Module):
                     reference_points.shape[-1]
                 )
             )
+        
+        # the original impl for fp32 training
         if torch.cuda.is_available() and value.is_cuda:
             output = MultiScaleDeformableAttnFunction.apply(
-                value,
+                value.to(torch.float32) if value.dtype==torch.float16 else value,
                 spatial_shapes,
                 level_start_index,
                 sampling_locations,
@@ -337,6 +339,9 @@ class MultiScaleDeformableAttention(nn.Module):
             output = multi_scale_deformable_attn_pytorch(
                 value, spatial_shapes, sampling_locations, attention_weights
             )
+
+        if value.dtype==torch.float16:
+            output=output.to(torch.float16)
 
         output = self.output_proj(output)
 

--- a/projects/dino/README.md
+++ b/projects/dino/README.md
@@ -32,6 +32,14 @@ Hao Zhang, Feng Li, Shilong Liu, Lei Zhang, Hang Su, Jun Zhu, Lionel M. Ni, Heun
 <td align="center">49.2</td>
 <td align="center"> <a href="https://github.com/IDEA-Research/detrex-storage/releases/download/v0.2.0/dino_r50_4scale_12ep_49_2AP.pth">model</a></td>
 </tr>
+ <tr><td align="left">DINO-R50-4scale <b> with AMP</b></td>
+<td align="center">R-50</td>
+<td align="center">IN1k</td>
+<td align="center">12</td>
+<td align="center">100</td>
+<td align="center">49.1</td>
+<td align="center"> - </td>
+</tr>
 <!-- ROW: dino_r50_4scale_12ep -->
  <tr><td align="left"><a href="configs/dino_r50_5scale_12ep.py">DINO-R50-5scale</a></td>
 <td align="center">R-50</td>
@@ -251,6 +259,7 @@ Hao Zhang, Feng Li, Shilong Liu, Lei Zhang, Hang Su, Jun Zhu, Lionel M. Ni, Heun
 - `Swin-X-384` means the backbone pretrained resolution is `384 x 384` and `IN22k to In1k` means the model is pretrained on `ImageNet-22k` and finetuned on `ImageNet-1k`.
 - ViT backbone using MAE pretraining weights following [ViTDet](https://github.com/facebookresearch/detectron2/tree/main/projects/ViTDet)  which can be downloaded in [MAE](https://github.com/facebookresearch/mae). And it's not stable to train ViTDet-DINO without warmup lr-scheduler.
 - `Focal-LRF-3Level`: means using `Large-Receptive-Field (LRF)` and `Focal-Level` is setted to `3`, please refer to [FocalNet](https://github.com/microsoft/FocalNet) for more details about the backbone settings.
+- `with AMP`: means using mixed precision training.
 
 **Notable facts and caveats**: The position embedding of DINO in detrex is different from the original repo. We set the tempureture and offsets in `PositionEmbeddingSine` to `10000` and `-0.5` which may make the model converge a little bit faster in the early stage and get a slightly better results (about 0.1mAP) in 12 epochs settings.
 


### PR DESCRIPTION
## TODO
- [x] support fp16 training, which will **reduce 20-30% GPU memory usage**.
- [x] fp16 training baseline **dino-r50-4scale-12ep**: `49.1 AP (with amp)` vs `49.2 AP (w/o amp)`

## Note
For `MultiScaleDeformableAttention`, we simply convert the input value to `torch.float32` and convert the output from `torch.float32` to `torch.float16`, which means we **skip fp16 and conduct fp32 computation** in `MultiScaleDeformableAttention` operator.

## Usage
start fp16 training with `train.amp.enabled`:

```bash
python tools/train_net.py \
    --config-file projects/dab_detr/configs/dab_detr_r50_50ep.py \
    --num-gpus 8 \
    train.amp.enabled=True
```