### PR TITLE
[Feature] Add AutoAugment and clean dataset mapper

### DIFF
--- a/configs/common/data/coco_detr.py
+++ b/configs/common/data/coco_detr.py
@@ -58,10 +58,12 @@ dataloader.test = L(build_detection_test_loader)(
     mapper=L(DetrDatasetMapper)(
         augmentation=L(AutoAugment)(
             policies=[
-                L(T.ResizeShortestEdge)(
-                    short_edge_length=800,
-                    max_size=1333,
-                ),
+                [
+                    L(T.ResizeShortestEdge)(
+                        short_edge_length=800,
+                        max_size=1333,
+                    ),
+                ]
             ],
         ),
         is_train=False,

--- a/configs/common/data/coco_detr.py
+++ b/configs/common/data/coco_detr.py
@@ -9,37 +9,42 @@ from detectron2.data import (
 )
 from detectron2.evaluation import COCOEvaluator
 
-from detrex.data import DetrDatasetMapper
+from detrex.data.dataset_mappers.detr_dataset_mapper import DetrDatasetMapper
+from detrex.data.transforms import AutoAugment
 
 dataloader = OmegaConf.create()
 
 dataloader.train = L(build_detection_train_loader)(
     dataset=L(get_detection_dataset_dicts)(names="coco_2017_train"),
     mapper=L(DetrDatasetMapper)(
-        augmentation=[
-            L(T.RandomFlip)(),
-            L(T.ResizeShortestEdge)(
-                short_edge_length=(480, 512, 544, 576, 608, 640, 672, 704, 736, 768, 800),
-                max_size=1333,
-                sample_style="choice",
-            ),
-        ],
-        augmentation_with_crop=[
-            L(T.RandomFlip)(),
-            L(T.ResizeShortestEdge)(
-                short_edge_length=(400, 500, 600),
-                sample_style="choice",
-            ),
-            L(T.RandomCrop)(
-                crop_type="absolute_range",
-                crop_size=(384, 600),
-            ),
-            L(T.ResizeShortestEdge)(
-                short_edge_length=(480, 512, 544, 576, 608, 640, 672, 704, 736, 768, 800),
-                max_size=1333,
-                sample_style="choice",
-            ),
-        ],
+        augmentation=L(AutoAugment)(
+            policies=[
+                [
+                    L(T.RandomFlip)(),
+                    L(T.ResizeShortestEdge)(
+                        short_edge_length=(480, 512, 544, 576, 608, 640, 672, 704, 736, 768, 800),
+                        max_size=1333,
+                        sample_style="choice",
+                    ),
+                ],
+                [
+                    L(T.RandomFlip)(),
+                    L(T.ResizeShortestEdge)(
+                        short_edge_length=(400, 500, 600),
+                        sample_style="choice",
+                    ),
+                    L(T.RandomCrop)(
+                        crop_type="absolute_range",
+                        crop_size=(384, 600),
+                    ),
+                    L(T.ResizeShortestEdge)(
+                        short_edge_length=(480, 512, 544, 576, 608, 640, 672, 704, 736, 768, 800),
+                        max_size=1333,
+                        sample_style="choice",
+                    ),
+                ],
+            ],
+        ),
         is_train=True,
         mask_on=False,
         img_format="RGB",
@@ -51,13 +56,14 @@ dataloader.train = L(build_detection_train_loader)(
 dataloader.test = L(build_detection_test_loader)(
     dataset=L(get_detection_dataset_dicts)(names="coco_2017_val", filter_empty=False),
     mapper=L(DetrDatasetMapper)(
-        augmentation=[
-            L(T.ResizeShortestEdge)(
-                short_edge_length=800,
-                max_size=1333,
-            ),
-        ],
-        augmentation_with_crop=None,
+        augmentation=L(AutoAugment)(
+            policies=[
+                L(T.ResizeShortestEdge)(
+                    short_edge_length=800,
+                    max_size=1333,
+                ),
+            ],
+        ),
         is_train=False,
         mask_on=False,
         img_format="RGB",

--- a/detrex/data/dataset_mappers/detr_dataset_mapper.py
+++ b/detrex/data/dataset_mappers/detr_dataset_mapper.py
@@ -48,7 +48,6 @@ class DetrDatasetMapper:
     Args:
         augmentation (list[detectron.data.Transforms]): The geometric transforms for
             the input raw image and annotations.
-        augmentation_with_crop (list[detectron.data.Transforms]): The geometric transforms with crop.
         is_train (bool): Whether to load train set or val set. Default: True.
         mask_on (bool): Whether to return the mask annotations. Default: False.
         img_format (str): The format of the input raw images. Default: RGB.
@@ -60,17 +59,15 @@ class DetrDatasetMapper:
     def __init__(
         self,
         augmentation,
-        augmentation_with_crop,
         is_train=True,
         mask_on=False,
         img_format="RGB",
     ):
         self.mask_on = mask_on
         self.augmentation = augmentation
-        self.augmentation_with_crop = augmentation_with_crop
         logger.info(
-            "Full TransformGens used in training: {}, crop: {}".format(
-                str(self.augmentation), str(self.augmentation_with_crop)
+            "Full TransformGens used in training: {}.".format(
+                str(self.augmentation)
             )
         )
 
@@ -89,13 +86,8 @@ class DetrDatasetMapper:
         image = utils.read_image(dataset_dict["file_name"], format=self.img_format)
         utils.check_image_size(dataset_dict, image)
 
-        if self.augmentation_with_crop is None:
-            image, transforms = T.apply_transform_gens(self.augmentation, image)
-        else:
-            if np.random.rand() > 0.5:
-                image, transforms = T.apply_transform_gens(self.augmentation, image)
-            else:
-                image, transforms = T.apply_transform_gens(self.augmentation_with_crop, image)
+        aug_input = T.AugInput(image=image)
+        transforms = self.augmentation(aug_input)
 
         image_shape = image.shape[:2]  # h, w
 

--- a/detrex/data/dataset_mappers/detr_dataset_mapper.py
+++ b/detrex/data/dataset_mappers/detr_dataset_mapper.py
@@ -88,6 +88,7 @@ class DetrDatasetMapper:
 
         aug_input = T.AugInput(image=image)
         transforms = self.augmentation(aug_input)
+        image = aug_input.image
 
         image_shape = image.shape[:2]  # h, w
 

--- a/detrex/data/transforms/__init__.py
+++ b/detrex/data/transforms/__init__.py
@@ -14,3 +14,4 @@
 # limitations under the License.
 
 from .color_augmentation import ColorAugSSDTransform
+from .auto_augmentation import AutoAugment

--- a/detrex/data/transforms/auto_augmentation.py
+++ b/detrex/data/transforms/auto_augmentation.py
@@ -1,0 +1,50 @@
+# coding=utf-8
+# Copyright 2022 The IDEA Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import random
+from omegaconf.listconfig import ListConfig
+
+from detectron2.data import transforms as T
+from detectron2.data.transforms.augmentation import Augmentation
+
+
+class AutoAugment(object):
+    def __init__(self, policies):
+        assert isinstance(policies, (list, ListConfig)) and len(policies) > 0, \
+            'Policies must be a non-empty list.'
+        for policy in policies:
+            assert isinstance(policy, (list, ListConfig)) and len(policy) > 0, \
+                'Each policy in policies must be a non-empty list.'
+            for augment in policy:
+                assert isinstance(augment, Augmentation), \
+                    "Each specific augmentation should be the class of \
+                        detectron2.data.transforms.Augmentation"
+        
+        self.policies = copy.deepcopy(policies)
+
+
+    def __call__(self, inputs):
+        augmentation = random.choice(self.policies)
+        
+        # this is an hack to avoid using omegaconf.listconfig.ListConfig
+        augmentation = list(augmentation)
+        augmentation = T.AugmentationList(augmentation)
+
+        return augmentation(inputs)
+
+
+    def __repr__(self):
+        return f'{self.__class__.__name__}(policies={self.policies})'


### PR DESCRIPTION
## TODO
- [x] Add `AutoAugment` as [mmdet.pipeline.auto_augment](https://mmdetection.readthedocs.io/en/v2.10.0/_modules/mmdet/datasets/pipelines/auto_augment.html)
- [x] Clean `detr_dataset_mapper` for better usage and code quality
- [ ] Verify `DINO-R50` AP: `48.94AP (exp-1)`

## Example
- The cleaned config: **only with one `augmentation` args** (without passing augmentation and augmentation_with_crop)
```python
from omegaconf import OmegaConf

import detectron2.data.transforms as T
from detectron2.config import LazyCall as L
from detectron2.data import (
    build_detection_test_loader,
    build_detection_train_loader,
    get_detection_dataset_dicts,
)
from detectron2.evaluation import COCOEvaluator

from detrex.data.dataset_mappers.detr_dataset_mapper import DetrDatasetMapper
from detrex.data.transforms import AutoAugment

dataloader = OmegaConf.create()

dataloader.train = L(build_detection_train_loader)(
    dataset=L(get_detection_dataset_dicts)(names="coco_2017_train"),
    mapper=L(DetrDatasetMapper)(
        augmentation=L(AutoAugment)(
            policies=[
                [
                    L(T.RandomFlip)(),
                    L(T.ResizeShortestEdge)(
                        short_edge_length=(480, 512, 544, 576, 608, 640, 672, 704, 736, 768, 800),
                        max_size=1333,
                        sample_style="choice",
                    ),
                ],
                [
                    L(T.RandomFlip)(),
                    L(T.ResizeShortestEdge)(
                        short_edge_length=(400, 500, 600),
                        sample_style="choice",
                    ),
                    L(T.RandomCrop)(
                        crop_type="absolute_range",
                        crop_size=(384, 600),
                    ),
                    L(T.ResizeShortestEdge)(
                        short_edge_length=(480, 512, 544, 576, 608, 640, 672, 704, 736, 768, 800),
                        max_size=1333,
                        sample_style="choice",
                    ),
                ],
            ],
        ),
        is_train=True,
        mask_on=False,
        img_format="RGB",
    ),
    total_batch_size=16,
    num_workers=4,
)

dataloader.test = L(build_detection_test_loader)(
    dataset=L(get_detection_dataset_dicts)(names="coco_2017_val", filter_empty=False),
    mapper=L(DetrDatasetMapper)(
        augmentation=L(AutoAugment)(
            policies=[
                L(T.ResizeShortestEdge)(
                    short_edge_length=800,
                    max_size=1333,
                ),
            ],
        ),
        is_train=False,
        mask_on=False,
        img_format="RGB",
    ),
    num_workers=4,
)

dataloader.evaluator = L(COCOEvaluator)(
    dataset_name="${..test.dataset.names}",
)

```