### PR TITLE
[Feature] Add torchvision resnet backbone and convert detr official weights into detrex format

### DIFF
--- a/detrex/modeling/backbone/torchvision_resnet.py
+++ b/detrex/modeling/backbone/torchvision_resnet.py
@@ -1,0 +1,106 @@
+# coding=utf-8
+# Copyright 2022 The IDEA Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------------------------
+# Copyright (c) Facebook, Inc. and its affiliates.
+# ------------------------------------------------------------------------------------------------
+# Modified from:
+# https://github.com/facebookresearch/detr/blob/main/models/backbone.py
+# ------------------------------------------------------------------------------------------------
+
+from collections import OrderedDict
+
+import torch
+import torch.nn as nn
+import torchvision
+from torchvision.models._utils import IntermediateLayerGetter
+
+from detectron2.utils.comm import is_main_process
+
+
+class FrozenBatchNorm2d(torch.nn.Module):
+    """
+    BatchNorm2d where the batch statistics and the affine parameters are fixed.
+    Copy-paste from torchvision.misc.ops with added eps before rqsrt,
+    without which any other models than torchvision.models.resnet[18,34,50,101]
+    produce nans.
+    """
+
+    def __init__(self, n):
+        super(FrozenBatchNorm2d, self).__init__()
+        self.register_buffer("weight", torch.ones(n))
+        self.register_buffer("bias", torch.zeros(n))
+        self.register_buffer("running_mean", torch.zeros(n))
+        self.register_buffer("running_var", torch.ones(n))
+
+    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
+                              missing_keys, unexpected_keys, error_msgs):
+        num_batches_tracked_key = prefix + 'num_batches_tracked'
+        if num_batches_tracked_key in state_dict:
+            del state_dict[num_batches_tracked_key]
+
+        super(FrozenBatchNorm2d, self)._load_from_state_dict(
+            state_dict, prefix, local_metadata, strict,
+            missing_keys, unexpected_keys, error_msgs)
+
+    def forward(self, x):
+        # move reshapes to the beginning
+        # to make it fuser-friendly
+        w = self.weight.reshape(1, -1, 1, 1)
+        b = self.bias.reshape(1, -1, 1, 1)
+        rv = self.running_var.reshape(1, -1, 1, 1)
+        rm = self.running_mean.reshape(1, -1, 1, 1)
+        eps = 1e-5
+        scale = w * (rv + eps).rsqrt()
+        bias = b - rm * scale
+        return x * scale + bias
+    
+
+class BackboneBase(nn.Module):
+    def __init__(
+            self, 
+            backbone: nn.Module, 
+            train_backbone: bool, 
+            num_channels: int, 
+            return_layers: dict,
+        ):
+        super().__init__()
+        for name, parameter in backbone.named_parameters():
+            if not train_backbone or 'layer2' not in name and 'layer3' not in name and 'layer4' not in name:
+                parameter.requires_grad_(False)
+
+        self.body = IntermediateLayerGetter(backbone, return_layers=return_layers)
+        self.num_channels = num_channels
+
+    def forward(self, x):
+        xs = self.body(x)
+        out = {}
+        for name, x in xs.items():
+            out[name] = x
+        return out
+
+
+class TorchvisionResNet(BackboneBase):
+    """ResNet backbone with frozen BatchNorm."""
+    def __init__(self, 
+                 name: str,
+                 train_backbone: bool,
+                 return_layers: dict = {"layer4": "res5"},
+                 dilation: bool = False,
+                ):
+        backbone = getattr(torchvision.models, name)(
+            replace_stride_with_dilation=[False, False, dilation],
+            pretrained=False, norm_layer=FrozenBatchNorm2d)
+        num_channels = 512 if name in ('resnet18', 'resnet34') else 2048
+        super().__init__(backbone, train_backbone, num_channels, return_layers)

--- a/docs/source/tutorials/Model_Zoo.md
+++ b/docs/source/tutorials/Model_Zoo.md
@@ -119,12 +119,40 @@ Here we provides our pretrained baselines with **detrex**. And more pretrained w
 <td align="center">43.3</td>
 <td align="center"> <a href="https://github.com/IDEA-Research/detrex-storage/releases/download/v0.1.0/dab_detr_r50_50ep.pth"> model </a></td>
 </tr>
+ <tr><td align="left"><a href="https://github.com/IDEA-Research/detrex/blob/main/projects/dab_detr/configs/dab_detr_r50_3patterns_50ep.py">DAB-DETR-R50-3patterns (converted)</a></td>
+<td align="center">R-50</td>
+<td align="center">IN1k</td>
+<td align="center">50</td>
+<td align="center">42.8</td>
+<td align="center"> <a href="https://github.com/IDEA-Research/detrex-storage/releases/download/v0.3.0/converted_dab_detr_r50_3patterns.pth">model</a></td>
+</tr>
+ <tr><td align="left"><a href="https://github.com/IDEA-Research/detrex/blob/main/projects/dab_detr/configs/dab_detr_r50_dc5_50ep.py">DAB-DETR-R50-DC5 (converted)</a></td>
+<td align="center">R-50</td>
+<td align="center">IN1k</td>
+<td align="center">50</td>
+<td align="center">44.6</td>
+<td align="center"> <a href="https://github.com/IDEA-Research/detrex-storage/releases/download/v0.3.0/converted_dab_detr_r50_dc5.pth">model</a></td>
+</tr>
+ <tr><td align="left"><a href="https://github.com/IDEA-Research/detrex/blob/main/projects/dab_detr/configs/dab_detr_r50_dc5_3patterns_50ep.py">DAB-DETR-R50-DC5-3patterns (converted)</a></td>
+<td align="center">R-50</td>
+<td align="center">IN1k</td>
+<td align="center">50</td>
+<td align="center">45.7</td>
+<td align="center"> <a href="https://github.com/IDEA-Research/detrex-storage/releases/download/v0.3.0/converted_dab_detr_r50_dc5_3patterns.pth">model</a></td>
+</tr>
  <tr><td align="left"> <a href="https://github.com/IDEA-Research/detrex/blob/main/projects/dab_detr/configs/dab_detr_r101_50ep.py"> DAB-DETR-R101 </a> </td>
 <td align="center">R101</td>
 <td align="center">IN1k</td>
 <td align="center">50</td>
 <td align="center">44.0</td>
 <td align="center"> <a href="https://github.com/IDEA-Research/detrex-storage/releases/download/v0.1.0/dab_detr_r101_50ep.pth"> model </a></td>
+</tr>
+ <tr><td align="left"><a href="https://github.com/IDEA-Research/detrex/blob/main/projects/dab_detr/configs/dab_detr_r50_dc5_3patterns_50ep.py">DAB-DETR-R101-DC5</a></td>
+<td align="center">R-101</td>
+<td align="center">IN1k</td>
+<td align="center">50</td>
+<td align="center">45.7</td>
+<td align="center"> <a href="https://github.com/IDEA-Research/detrex-storage/releases/download/v0.3.0/converted_detr_r101_dc5.pth">model</a></td>
 </tr>
  <tr><td align="left"> <a href="https://github.com/IDEA-Research/detrex/blob/main/projects/dab_detr/configs/dab_detr_swin_t_in1k_50ep.py"> DAB-DETR-Swin-T </a> </td>
 <td align="center">Swin-Tiny-224</td>

--- a/docs/source/tutorials/Model_Zoo.md
+++ b/docs/source/tutorials/Model_Zoo.md
@@ -7,7 +7,51 @@
 
 
 ## COCO Object Detection Baselines
-Here we provides our pretrained baselines with **detrex**. And more pretrained weights will be released in the future version.
+Here we provides our pretrained baselines with **detrex**. And more pretrained weights will be released in the future version. We also provide our converted pretrained for the users which will be marked as `(converted)`.
+
+### DETR
+<table class="docutils"><tbody>
+<!-- START TABLE -->
+<!-- TABLE HEADER -->
+<th valign="bottom">Name</th>
+<th valign="bottom">Backbone</th>
+<th valign="bottom">Pretrained</th>
+<th valign="bottom">Epochs</th>
+<th valign="bottom">box<br/>AP</th>
+<th valign="bottom">Download</th>
+<!-- TABLE BODY -->
+<!-- ROW: detr_r50 -->
+ <tr><td align="left"><a href="https://github.com/IDEA-Research/detrex/blob/main/projects/detr/configs/detr_r50_300ep.py">DETR-R50 (converted)</a></td>
+<td align="center">R-50</td>
+<td align="center">IN1k</td>
+<td align="center">500</td>
+<td align="center">42.0</td>
+<td align="center"> <a href="https://github.com/IDEA-Research/detrex-storage/releases/download/v0.1.0/converted_detr_r50_500ep.pth">model</a></td>
+<!-- ROW: detr_r50_dc5 -->
+ <tr><td align="left"><a href="https://github.com/IDEA-Research/detrex/blob/main/projects/detr/configs/detr_r50_dc5_300ep.py">DETR-R50-DC5 (converted)</a></td>
+<td align="center">R-50</td>
+<td align="center">IN1k</td>
+<td align="center">500</td>
+<td align="center">43.4</td>
+<td align="center"> <a href="https://github.com/IDEA-Research/detrex-storage/releases/download/v0.3.0/converted_detr_r50_dc5.pth">model</a></td>
+</tr>
+<!-- ROW: detr_r101 -->
+ <tr><td align="left"><a href="https://github.com/IDEA-Research/detrex/blob/main/projects/detr/configs/detr_r101_300ep.py">DETR-R101 (converted)</a></td>
+<td align="center">R-101</td>
+<td align="center">IN1k</td>
+<td align="center">500</td>
+<td align="center">43.5</td>
+<td align="center"> <a href="https://github.com/IDEA-Research/detrex-storage/releases/download/v0.1.0/converted_detr_r101_500ep.pth">model</a></td>
+</tr>
+<!-- ROW: detr_r101_dc5 -->
+ <tr><td align="left"><a href="https://github.com/IDEA-Research/detrex/blob/main/projects/detr/configs/detr_r101_dc5_300ep.py">DETR-R101-DC5 (converted)</a></td>
+<td align="center">R-101</td>
+<td align="center">IN1k</td>
+<td align="center">500</td>
+<td align="center">44.9</td>
+<td align="center"> <a href="https://github.com/IDEA-Research/detrex-storage/releases/download/v0.3.0/converted_detr_r101_dc5.pth">model</a></td>
+</tr>
+</tbody></table>
 
 ### Deformable-DETR
 <table class="docutils"><tbody>

--- a/docs/source/tutorials/Model_Zoo.md
+++ b/docs/source/tutorials/Model_Zoo.md
@@ -147,7 +147,7 @@ Here we provides our pretrained baselines with **detrex**. And more pretrained w
 <td align="center">44.0</td>
 <td align="center"> <a href="https://github.com/IDEA-Research/detrex-storage/releases/download/v0.1.0/dab_detr_r101_50ep.pth"> model </a></td>
 </tr>
- <tr><td align="left"><a href="https://github.com/IDEA-Research/detrex/blob/main/projects/dab_detr/configs/dab_detr_r50_dc5_3patterns_50ep.py">DAB-DETR-R101-DC5</a></td>
+ <tr><td align="left"><a href="https://github.com/IDEA-Research/detrex/blob/main/projects/dab_detr/configs/dab_detr_r50_dc5_3patterns_50ep.py">DAB-DETR-R101-DC5 (converted)</a></td>
 <td align="center">R-101</td>
 <td align="center">IN1k</td>
 <td align="center">50</td>

--- a/projects/dab_detr/README.md
+++ b/projects/dab_detr/README.md
@@ -75,6 +75,20 @@ Here are the converted the pretrained weights from [DAB-DETR](https://github.com
 <td align="center">44.6</td>
 <td align="center"> <a href="https://github.com/IDEA-Research/detrex-storage/releases/download/v0.3.0/converted_dab_detr_r50_dc5.pth">model</a></td>
 </tr>
+ <tr><td align="left"><a href="configs/dab_detr_r50_dc5_3patterns_50ep.py">DAB-DETR-R50-DC5-3patterns</a></td>
+<td align="center">R-50</td>
+<td align="center">IN1k</td>
+<td align="center">50</td>
+<td align="center">45.7</td>
+<td align="center"> <a href="https://github.com/IDEA-Research/detrex-storage/releases/download/v0.3.0/converted_dab_detr_r50_dc5_3patterns.pth">model</a></td>
+</tr>
+ <tr><td align="left"><a href="configs/dab_detr_r50_dc5_3patterns_50ep.py">DAB-DETR-R101-DC5</a></td>
+<td align="center">R-101</td>
+<td align="center">IN1k</td>
+<td align="center">50</td>
+<td align="center">45.7</td>
+<td align="center"> <a href="https://github.com/IDEA-Research/detrex-storage/releases/download/v0.3.0/converted_detr_r101_dc5.pth">model</a></td>
+</tr>
 </tbody></table>
 
 ## Training

--- a/projects/dab_detr/README.md
+++ b/projects/dab_detr/README.md
@@ -47,6 +47,28 @@ Here we provide the pretrained `DAB-DETR` weights based on detrex.
 </tbody></table>
 
 
+## Converted Models
+Here are the converted the pretrained weights from [DAB-DETR](https://github.com/IDEA-Research/DAB-DETR) official repo.
+<table><tbody>
+<!-- START TABLE -->
+<!-- TABLE HEADER -->
+<th valign="bottom">Name</th>
+<th valign="bottom">Backbone</th>
+<th valign="bottom">Pretrain</th>
+<th valign="bottom">Epochs</th>
+<th valign="bottom">box<br/>AP</th>
+<th valign="bottom">download</th>
+<!-- TABLE BODY -->
+<!-- ROW: dab_detr_r50_dc5_50ep -->
+ <tr><td align="left"><a href="configs/dab_detr_r50_dc5_50ep.py">DAB-DETR-R50-DC5</a></td>
+<td align="center">R-50</td>
+<td align="center">IN1k</td>
+<td align="center">50</td>
+<td align="center">44.6</td>
+<td align="center"> <a href="">model</a></td>
+</tr>
+</tbody></table>
+
 ## Training
 All configs can be trained with:
 ```bash

--- a/projects/dab_detr/README.md
+++ b/projects/dab_detr/README.md
@@ -59,13 +59,21 @@ Here are the converted the pretrained weights from [DAB-DETR](https://github.com
 <th valign="bottom">box<br/>AP</th>
 <th valign="bottom">download</th>
 <!-- TABLE BODY -->
+<!-- ROW: dab_detr_r50_3patterns_50ep -->
+ <tr><td align="left"><a href="configs/dab_detr_r50_3patterns_50ep.py">DAB-DETR-R50-3patterns</a></td>
+<td align="center">R-50</td>
+<td align="center">IN1k</td>
+<td align="center">50</td>
+<td align="center">42.8</td>
+<td align="center"> <a href="https://github.com/IDEA-Research/detrex-storage/releases/download/v0.3.0/converted_dab_detr_r50_3patterns.pth">model</a></td>
+</tr>
 <!-- ROW: dab_detr_r50_dc5_50ep -->
  <tr><td align="left"><a href="configs/dab_detr_r50_dc5_50ep.py">DAB-DETR-R50-DC5</a></td>
 <td align="center">R-50</td>
 <td align="center">IN1k</td>
 <td align="center">50</td>
 <td align="center">44.6</td>
-<td align="center"> <a href="">model</a></td>
+<td align="center"> <a href="https://github.com/IDEA-Research/detrex-storage/releases/download/v0.3.0/converted_dab_detr_r50_dc5.pth">model</a></td>
 </tr>
 </tbody></table>
 

--- a/projects/dab_detr/configs/dab_detr_r101_dc5_50ep.py
+++ b/projects/dab_detr/configs/dab_detr_r101_dc5_50ep.py
@@ -1,0 +1,14 @@
+from .dab_detr_r50_50ep import (
+    train,
+    dataloader,
+    optimizer,
+    lr_multiplier,
+)
+from .models.dab_detr_r50_dc5 import model
+
+# modify training config
+train.init_checkpoint = "https://download.pytorch.org/models/resnet101-63fe2227.pth"
+train.output_dir = "./output/dab_detr_r101_dc5_50ep"
+
+# modify model
+model.backbone.name = "resnet101"

--- a/projects/dab_detr/configs/dab_detr_r50_3patterns_50ep.py
+++ b/projects/dab_detr/configs/dab_detr_r50_3patterns_50ep.py
@@ -1,0 +1,14 @@
+from .dab_detr_r50_50ep import (
+    train,
+    dataloader,
+    optimizer,
+    lr_multiplier,
+    model,
+)
+
+# modify training config
+train.init_checkpoint = "detectron2://ImageNetPretrained/torchvision/R-50.pkl"
+train.output_dir = "./output/dab_detr_r50_3patterns_50ep"
+
+# using 3 pattern embeddings as in Anchor-DETR
+model.transformer.num_patterns = 3

--- a/projects/dab_detr/configs/dab_detr_r50_dc5_3patterns_50ep.py
+++ b/projects/dab_detr/configs/dab_detr_r50_dc5_3patterns_50ep.py
@@ -1,0 +1,17 @@
+from .dab_detr_r50_dc5_50ep import (
+    train,
+    dataloader,
+    optimizer,
+    lr_multiplier,
+    model,
+)
+
+# modify training config
+train.init_checkpoint = "https://download.pytorch.org/models/resnet50-0676ba61.pth"
+train.output_dir = "./output/dab_detr_r50_dc5_3patterns_50ep"
+
+# using 3 pattern embeddings as in Anchor-DETR
+model.transformer.num_patterns = 3
+
+# modify model
+model.position_embedding.temperature = 20

--- a/projects/dab_detr/configs/dab_detr_r50_dc5_50ep.py
+++ b/projects/dab_detr/configs/dab_detr_r50_dc5_50ep.py
@@ -7,5 +7,5 @@ from .dab_detr_r50_50ep import (
 from .models.dab_detr_r50_dc5 import model
 
 # modify training config
-train.init_checkpoint = "detectron2://ImageNetPretrained/torchvision/R-50.pkl"
+train.init_checkpoint = "https://download.pytorch.org/models/resnet50-0676ba61.pth"
 train.output_dir = "./output/dab_detr_r50_dc5_50ep"

--- a/projects/dab_detr/configs/dab_detr_r50_dc5_50ep.py
+++ b/projects/dab_detr/configs/dab_detr_r50_dc5_50ep.py
@@ -9,3 +9,6 @@ from .models.dab_detr_r50_dc5 import model
 # modify training config
 train.init_checkpoint = "https://download.pytorch.org/models/resnet50-0676ba61.pth"
 train.output_dir = "./output/dab_detr_r50_dc5_50ep"
+
+# modify model
+model.position_embedding.temperature = 10

--- a/projects/dab_detr/configs/models/dab_detr_r50.py
+++ b/projects/dab_detr/configs/models/dab_detr_r50.py
@@ -52,6 +52,7 @@ model = L(DABDETR)(
             num_layers=6,
             modulate_hw_attn=True,
         ),
+        num_patterns=0,  # pattern embedding as in Anchor-DETR
     ),
     embed_dim=256,
     num_classes=80,

--- a/projects/dab_detr/configs/models/dab_detr_r50_3patterns.py
+++ b/projects/dab_detr/configs/models/dab_detr_r50_3patterns.py
@@ -1,0 +1,5 @@
+from .dab_detr_r50 import model
+
+
+# using 3 pattern embeddings as in Anchor-DETR
+model.transformer.num_patterns = 3

--- a/projects/dab_detr/configs/models/dab_detr_r50_dc5.py
+++ b/projects/dab_detr/configs/models/dab_detr_r50_dc5.py
@@ -1,17 +1,12 @@
 from detectron2.config import LazyCall as L
-from detrex.modeling.backbone import ResNet, BasicStem, make_stage
+from detrex.modeling.backbone.torchvision_resnet import TorchvisionResNet
 
 from .dab_detr_r50 import model
 
 
-model.backbone = L(ResNet)(
-    stem=L(BasicStem)(in_channels=3, out_channels=64, norm="FrozenBN"),
-    stages=L(make_stage)(
-        depth=50,
-        stride_in_1x1=False,
-        norm="FrozenBN",
-        res5_dilation=2,
-    ),
-    out_features=["res2", "res3", "res4", "res5"],
-    freeze_at=1,
+model.backbone=L(TorchvisionResNet)(
+    name="resnet50",
+    train_backbone=True,
+    dilation=True,
+    return_layers={"layer4": "res5"}
 )

--- a/projects/detr/README.md
+++ b/projects/detr/README.md
@@ -24,7 +24,7 @@ Here we provides the weights which are converted by [converter.py](./converter.p
 <th valign="bottom">download</th>
 <!-- TABLE BODY -->
 <!-- ROW: detr_r50 -->
- <tr><td align="left"><a>DETR-R50</a></td>
+ <tr><td align="left"><a href="configs/detr_r50_300ep.py">DETR-R50</a></td>
 <td align="center">R-50</td>
 <td align="center">IN1k</td>
 <td align="center">500</td>
@@ -32,15 +32,15 @@ Here we provides the weights which are converted by [converter.py](./converter.p
 <td align="center"> <a href="https://github.com/IDEA-Research/detrex-storage/releases/download/v0.1.0/converted_detr_r50_500ep.pth">model</a></td>
 </tr>
 <!-- ROW: detr_r50_dc5 -->
- <tr><td align="left"><a>DETR-R50-DC5</a></td>
+ <tr><td align="left"><a href="configs/detr_r50_dc5_300ep.py">DETR-R50-DC5</a></td>
 <td align="center">R-50</td>
 <td align="center">IN1k</td>
 <td align="center">500</td>
 <td align="center">43.4</td>
-<td align="center"> <a href="">model</a></td>
+<td align="center"> <a href="https://github.com/IDEA-Research/detrex-storage/releases/download/v0.3.0/converted_detr_r50_dc5.pth">model</a></td>
 </tr>
 <!-- ROW: detr_r101 -->
- <tr><td align="left"><a>DETR-R101</a></td>
+ <tr><td align="left"><a href="configs/detr_r101_300ep.py">DETR-R101</a></td>
 <td align="center">R-101</td>
 <td align="center">IN1k</td>
 <td align="center">500</td>
@@ -48,12 +48,12 @@ Here we provides the weights which are converted by [converter.py](./converter.p
 <td align="center"> <a href="https://github.com/IDEA-Research/detrex-storage/releases/download/v0.1.0/converted_detr_r101_500ep.pth">model</a></td>
 </tr>
 <!-- ROW: detr_r101_dc5 -->
- <tr><td align="left"><a>DETR-R101-DC5</a></td>
+ <tr><td align="left"><a href="configs/detr_r101_dc5_300ep.py">DETR-R101-DC5</a></td>
 <td align="center">R-101</td>
 <td align="center">IN1k</td>
 <td align="center">500</td>
-<td align="center">43.5</td>
-<td align="center"> <a href="">model</a></td>
+<td align="center">44.9</td>
+<td align="center"> <a href="https://github.com/IDEA-Research/detrex-storage/releases/download/v0.3.0/converted_detr_r101_dc5.pth">model</a></td>
 </tr>
 </tbody></table>
 

--- a/projects/detr/README.md
+++ b/projects/detr/README.md
@@ -31,13 +31,29 @@ Here we provides the weights which are converted by [converter.py](./converter.p
 <td align="center">42.0</td>
 <td align="center"> <a href="https://github.com/IDEA-Research/detrex-storage/releases/download/v0.1.0/converted_detr_r50_500ep.pth">model</a></td>
 </tr>
-<!-- ROW: detr_r50 -->
- <tr><td align="left"><a>DETR-R101</a></td>
+<!-- ROW: detr_r50_dc5 -->
+ <tr><td align="left"><a>DETR-R50-DC5</a></td>
 <td align="center">R-50</td>
+<td align="center">IN1k</td>
+<td align="center">500</td>
+<td align="center">43.4</td>
+<td align="center"> <a href="">model</a></td>
+</tr>
+<!-- ROW: detr_r101 -->
+ <tr><td align="left"><a>DETR-R101</a></td>
+<td align="center">R-101</td>
 <td align="center">IN1k</td>
 <td align="center">500</td>
 <td align="center">43.5</td>
 <td align="center"> <a href="https://github.com/IDEA-Research/detrex-storage/releases/download/v0.1.0/converted_detr_r101_500ep.pth">model</a></td>
+</tr>
+<!-- ROW: detr_r101_dc5 -->
+ <tr><td align="left"><a>DETR-R101-DC5</a></td>
+<td align="center">R-101</td>
+<td align="center">IN1k</td>
+<td align="center">500</td>
+<td align="center">43.5</td>
+<td align="center"> <a href="">model</a></td>
 </tr>
 </tbody></table>
 

--- a/projects/detr/configs/detr_r101_dc5_300ep.py
+++ b/projects/detr/configs/detr_r101_dc5_300ep.py
@@ -10,4 +10,4 @@ train.init_checkpoint = "https://download.pytorch.org/models/resnet101-63fe2227.
 train.output_dir = "./output/detr_r50_dc5_300ep"
 
 # modify model
-model.name = "resnet101"
+model.backbone.name = "resnet101"

--- a/projects/detr/configs/detr_r101_dc5_300ep.py
+++ b/projects/detr/configs/detr_r101_dc5_300ep.py
@@ -1,0 +1,13 @@
+from .detr_r50_300ep import dataloader, lr_multiplier, optimizer, train
+
+from .models.detr_r50_dc5 import model
+
+# modify training config
+# using torchvision official checkpoint
+# the urls can be found in: https://pytorch.org/vision/stable/models/resnet.html
+
+train.init_checkpoint = "https://download.pytorch.org/models/resnet101-63fe2227.pth"
+train.output_dir = "./output/detr_r50_dc5_300ep"
+
+# modify model
+model.name = "resnet101"

--- a/projects/detr/configs/detr_r50_dc5_300ep.py
+++ b/projects/detr/configs/detr_r50_dc5_300ep.py
@@ -1,0 +1,11 @@
+from .detr_r50_300ep import dataloader, lr_multiplier, optimizer, train
+
+from .models.detr_r50_dc5 import model
+
+# modify training config
+# using torchvision official checkpoint
+# the urls can be found in: https://pytorch.org/vision/stable/models/resnet.html
+
+train.init_checkpoint = "https://download.pytorch.org/models/resnet50-0676ba61.pth"
+train.output_dir = "./output/detr_r50_dc5_300ep"
+

--- a/projects/detr/configs/models/detr_r50_dc5.py
+++ b/projects/detr/configs/models/detr_r50_dc5.py
@@ -1,0 +1,12 @@
+from detectron2.config import LazyCall as L
+
+from detrex.modeling.backbone.torchvision_resnet import TorchvisionResNet
+
+from .detr_r50 import model
+
+model.backbone=L(TorchvisionResNet)(
+    name="resnet50",
+    train_backbone=True,
+    dilation=True,
+    return_layers={"layer4": "res5"}
+)


### PR DESCRIPTION
## TODO
- [x] Add torchvision resnet backbone
- [x] Convert `DETR` official weights into detrex format: `DETR-R50-DC5`, `DETR-R101-DC5`
- [x] Convert `DAB-DETR` official weights into detrex format: `DAB-DETR-R50-DC5`, `DAB-DETR-R50-3patterns`, `DAB-R50-DC5-3patterns`, `DAB-R101-DC5`
- [x] Support `pattern embeddings` as Anchor-DETR in **DAB-DETR**

## Usage
```python
model.backbone=L(TorchvisionResNet)(
    name="resnet50",
    train_backbone=True,
    dilation=True,
    return_layers={"layer4": "res5"}
)
```
which will defaultly return the feature from last stage `layer4` and frozen the stem and first stage of resnet backbone.  Set `name="resnet101"` to use resnet-101 backbone.

## Simple Explanation
We've additionally implement `torchvision resnet` backbone which has been used in detr original repo. This is because there's some different when it comes to `R50-DC5` and `R101-DC5` models. 

In torchvision resnet50 model, there's **only two bottlenecks** have `dilation=2` in last stage
```bash
   (layer4): Sequential(
      (0): Bottleneck(
        (conv1): Conv2d(1024, 512, kernel_size=(1, 1), stride=(1, 1), bias=False)
        (bn1): FrozenBatchNorm2d()
        (conv2): Conv2d(512, 512, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)
        (bn2): FrozenBatchNorm2d()
        (conv3): Conv2d(512, 2048, kernel_size=(1, 1), stride=(1, 1), bias=False)
        (bn3): FrozenBatchNorm2d()
        (relu): ReLU(inplace=True)
        (downsample): Sequential(
          (0): Conv2d(1024, 2048, kernel_size=(1, 1), stride=(1, 1), bias=False)
          (1): FrozenBatchNorm2d()
        )
      )
      (1): Bottleneck(
        (conv1): Conv2d(2048, 512, kernel_size=(1, 1), stride=(1, 1), bias=False)
        (bn1): FrozenBatchNorm2d()
        (conv2): Conv2d(512, 512, kernel_size=(3, 3), stride=(1, 1), padding=(2, 2), dilation=(2, 2), bias=False)
        (bn2): FrozenBatchNorm2d()
        (conv3): Conv2d(512, 2048, kernel_size=(1, 1), stride=(1, 1), bias=False)
        (bn3): FrozenBatchNorm2d()
        (relu): ReLU(inplace=True)
      )
      (2): Bottleneck(
        (conv1): Conv2d(2048, 512, kernel_size=(1, 1), stride=(1, 1), bias=False)
        (bn1): FrozenBatchNorm2d()
        (conv2): Conv2d(512, 512, kernel_size=(3, 3), stride=(1, 1), padding=(2, 2), dilation=(2, 2), bias=False)
        (bn2): FrozenBatchNorm2d()
        (conv3): Conv2d(512, 2048, kernel_size=(1, 1), stride=(1, 1), bias=False)
        (bn3): FrozenBatchNorm2d()
        (relu): ReLU(inplace=True)
      )
    )
  )
)
```
But in d2 resnet, **all the bottlenecks** in last stage have `dilation=2`:
```bash
  (res5): Sequential(
    (0): BottleneckBlock(
      (shortcut): Conv2d(
        1024, 2048, kernel_size=(1, 1), stride=(1, 1), bias=False
        (norm): FrozenBatchNorm2d(num_features=2048, eps=1e-05)
      )
      (conv1): Conv2d(
        1024, 512, kernel_size=(1, 1), stride=(1, 1), bias=False
        (norm): FrozenBatchNorm2d(num_features=512, eps=1e-05)
      )
      (conv2): Conv2d(
        512, 512, kernel_size=(3, 3), stride=(1, 1), padding=(2, 2), dilation=(2, 2), bias=False
        (norm): FrozenBatchNorm2d(num_features=512, eps=1e-05)
      )
      (conv3): Conv2d(
        512, 2048, kernel_size=(1, 1), stride=(1, 1), bias=False
        (norm): FrozenBatchNorm2d(num_features=2048, eps=1e-05)
      )
    )
    (1): BottleneckBlock(
      (conv1): Conv2d(
        2048, 512, kernel_size=(1, 1), stride=(1, 1), bias=False
        (norm): FrozenBatchNorm2d(num_features=512, eps=1e-05)
      )
      (conv2): Conv2d(
        512, 512, kernel_size=(3, 3), stride=(1, 1), padding=(2, 2), dilation=(2, 2), bias=False
        (norm): FrozenBatchNorm2d(num_features=512, eps=1e-05)
      )
      (conv3): Conv2d(
        512, 2048, kernel_size=(1, 1), stride=(1, 1), bias=False
        (norm): FrozenBatchNorm2d(num_features=2048, eps=1e-05)
      )
    )
    (2): BottleneckBlock(
      (conv1): Conv2d(
        2048, 512, kernel_size=(1, 1), stride=(1, 1), bias=False
        (norm): FrozenBatchNorm2d(num_features=512, eps=1e-05)
      )
      (conv2): Conv2d(
        512, 512, kernel_size=(3, 3), stride=(1, 1), padding=(2, 2), dilation=(2, 2), bias=False
        (norm): FrozenBatchNorm2d(num_features=512, eps=1e-05)
      )
      (conv3): Conv2d(
        512, 2048, kernel_size=(1, 1), stride=(1, 1), bias=False
        (norm): FrozenBatchNorm2d(num_features=2048, eps=1e-05)
      )
    )
  )
)
```
