### PR TITLE
Questionable Width and Height Recalculation for Maskdino 

### DIFF
--- a/projects/maskdino/maskdino.py
+++ b/projects/maskdino/maskdino.py
@@ -217,8 +217,6 @@ class MaskDINO(nn.Module):
                 # import ipdb; ipdb.set_trace()
                 if self.instance_on:
                     mask_box_result = mask_box_result.to(mask_pred_result)
-                    height = new_size[0]/image_size[0]*height
-                    width = new_size[1]/image_size[1]*width
                     mask_box_result = self.box_postprocess(mask_box_result, height, width)
 
                     instance_r = retry_if_cuda_oom(self.instance_inference)(mask_cls_result, mask_pred_result, mask_box_result)


### PR DESCRIPTION
I think there might be a bug when resizing the bounding box in maskdino. The width and height is calculated twice. At first it is read from the dict "input_per_image" like so in [lines 190-191](https://github.com/IDEA-Research/detrex/blob/main/projects/maskdino/maskdino.py#L220):

```
height = input_per_image.get("height", image_size[0])  # real size
width = input_per_image.get("width", image_size[1])
```
and then it is recalculated again in [lines 220-221](https://github.com/IDEA-Research/detrex/blob/main/projects/maskdino/maskdino.py#L220):
```
height = new_size[0]/image_size[0]*height
width = new_size[1]/image_size[1]*width
```
In my case, the final width exceeds the width of the original image. 

This might also be related to #242 where we saw shifted bounding boxes. 