### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ psutil
 opencv-python
 wandb
 submitit
+einops


### PR DESCRIPTION
In `detrex/modeling/backbone/eva_02_utils.py`, `einops` is used, but it is not listed in `requirements.txt`.