### PR TITLE
Fix wandb init

### DIFF
--- a/detrex/utils/events.py
+++ b/detrex/utils/events.py
@@ -15,6 +15,7 @@
 
 import wandb
 from PIL import Image
+from omegaconf import OmegaConf
 
 from detectron2.utils.events import EventWriter, get_event_storage
 
@@ -35,7 +36,7 @@ class WandbWriter(EventWriter):
         self._window_size = window_size
 
         self._writer = wandb.init(
-            config=cfg,
+            config=OmegaConf.to_container(cfg, resolve=True),
             **cfg.train.wandb.params,
         )
         self._last_write = -1


### PR DESCRIPTION
The OmegaConf version in my environment is 2.1.0 and the wandb version is 0.15.8 
When enable wandb, it encounters an error about the 'config' argument in wandb.init().  It seems that the initialization of wandb does not support DictConfig. 
I refer to the solution  in [https://docs.wandb.ai/guides/integrations/hydra#track-hyperparameters](https://docs.wandb.ai/guides/integrations/hydra#track-hyperparameters) and  modify the corresponding codes.