### PR TITLE
Allow more flexible CUDA build environment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ def get_extensions():
     extra_compile_args = {"cxx": []}
     define_macros = []
 
-    if torch.cuda.is_available() and CUDA_HOME is not None:
+    if (torch.cuda.is_available() and CUDA_HOME is not None) or os.getenv("FORCE_CUDA", "0") == "1":
         extension = CUDAExtension
         sources += source_cuda
         define_macros += [("WITH_CUDA", None)]


### PR DESCRIPTION
This change allows for a correct build using get_extensions() to occur outside of a CUDA environment. This addresses the import error of `import detrex._C` when running multi_scale_deform_attn.py