### PR TITLE
Add ROCm Platform Support to detrex

### DIFF
--- a/detrex/layers/csrc/cuda_version.cu
+++ b/detrex/layers/csrc/cuda_version.cu
@@ -2,6 +2,8 @@
 
 namespace detrex {
 int get_cudart_version() {
-  return CUDART_VERSION;
+  int runtimeVersion;
+  cudaRuntimeGetVersion(&runtimeVersion);
+  return runtimeVersion;
 }
 } // namespace detrex


### PR DESCRIPTION
## Description:

This PR adds support for the ROCm platform to the `detrex` project. ROCm (Radeon Open Compute) is a parallel computing platform developed by AMD that allows developers to leverage AMD GPUs for machine learning and high-performance computing applications. This update includes necessary code modifications, build scripts, and documentation updates to ensure compatibility and optimal performance on ROCm-enabled systems.

## Changes:

1. **Updated `setup.py`:**
   - Included ROCm-specific dependencies to ensure compatibility with the ROCm platform.

2. **Modified CUDA Version Retrieval:**
   - Updated the method of obtaining the runtime version in `detrex/layers/csrc/cuda_version.cu`. The original implementation used `CUDART_VERSION` from the CUDA library, which does not automatically translate to the HIP API using `hipify`.
   - Replaced `CUDART_VERSION` with a call to the `cudaRuntimeGetVersion` API. This change allows the code to be translated to `hipRuntimeGetVersion` by `hipify`, ensuring compatibility with the ROCm platform.

**Checklist:**

- [x] Code changes have been tested and verified on ROCm and CUDA system.

---

Please review the changes and provide feedback. Any suggestions for improvement or additional testing are welcome.

Thank you!