### PR TITLE
Fixed CPU only install

### DIFF
--- a/detrex/layers/csrc/DCNv3/dcnv3_cpu.cpp
+++ b/detrex/layers/csrc/DCNv3/dcnv3_cpu.cpp
@@ -12,7 +12,10 @@
 #include <vector>
 
 #include <ATen/ATen.h>
+
+#ifdef WITH_CUDA
 #include <ATen/cuda/CUDAContext.h>
+#endif
 
 at::Tensor dcnv3_cpu_forward(const at::Tensor &input, const at::Tensor &offset,
                              const at::Tensor &mask, const int kernel_h,

--- a/detrex/layers/csrc/MsDeformAttn/ms_deform_attn_cpu.cpp
+++ b/detrex/layers/csrc/MsDeformAttn/ms_deform_attn_cpu.cpp
@@ -11,7 +11,10 @@
 #include <vector>
 
 #include <ATen/ATen.h>
+
+#ifdef WITH_CUDA
 #include <ATen/cuda/CUDAContext.h>
+#endif
 
 namespace detrex {
 


### PR DESCRIPTION
I couldn't get past the `FORCE_CUDA=0 pip install -e .` step for my CPU-only installation while following the[ installation guide](https://detrex.readthedocs.io/en/latest/tutorials/Installation.html). I managed to complete and test my installation with the fix proposed in this PR.

Do not forget to change the config to `train.device = "cpu"` in  _dn_detr_r50_50ep.py_ when running the demo test:
```
python demo/demo.py --config-file projects/dab_detr/configs/dab_detr_r50_50ep.py \
                    --input "./idea.jpg" \
                    --output "./demo_output.jpg" \
                    --opts train.init_checkpoint="./dab_detr_r50_50ep.pth"
```